### PR TITLE
Adjust doc title

### DIFF
--- a/docs/antora.yml
+++ b/docs/antora.yml
@@ -1,5 +1,5 @@
 name: quarkus-ngrok
-title: '- Ngrok'
+title: Ngrok
 version: dev
 nav:
   - modules/ROOT/nav.adoc

--- a/docs/antora.yml
+++ b/docs/antora.yml
@@ -1,5 +1,5 @@
 name: quarkus-ngrok
-title: Quarkus - Ngrok
+title: '- Ngrok'
 version: dev
 nav:
   - modules/ROOT/nav.adoc


### PR DESCRIPTION
This will remove the  `Quarkus ` prefix in the documentation title