### PR TITLE
NGrok 3.5.0 Client Fixes

### DIFF
--- a/deployment/src/main/java/io/quarkiverse/ngrok/deployment/NgrokDevModeListener.java
+++ b/deployment/src/main/java/io/quarkiverse/ngrok/deployment/NgrokDevModeListener.java
@@ -215,6 +215,7 @@ public class NgrokDevModeListener implements DevModeListener {
             command = List.of(ngrokBinary.toAbsolutePath().toString(), "http", quarkusHttpPort.toString());
         } else {
             StringBuilder sb = new StringBuilder();
+            sb.append("version: 2").append(System.lineSeparator());
             if (authToken.isPresent()) {
                 sb.append("authtoken: ").append(authToken.get()).append(System.lineSeparator());
             }
@@ -227,7 +228,7 @@ public class NgrokDevModeListener implements DevModeListener {
             try {
                 Path configFile = Files.createTempFile("ngrok", ".yml");
                 Files.writeString(configFile, sb.toString());
-                command = List.of(ngrokBinary.toAbsolutePath().toString(), "http", "-config=" + configFile.toAbsolutePath(),
+                command = List.of(ngrokBinary.toAbsolutePath().toString(), "http", "--config=" + configFile.toAbsolutePath(),
                         quarkusHttpPort.toString());
             } catch (IOException e) {
                 log.warn("Unable to create ngrok configuration file", e);

--- a/deployment/src/main/java/io/quarkiverse/ngrok/deployment/VertxNgrokClient.java
+++ b/deployment/src/main/java/io/quarkiverse/ngrok/deployment/VertxNgrokClient.java
@@ -57,7 +57,7 @@ public class VertxNgrokClient implements NgrokClient {
                 .atMost(Duration.ofSeconds(5));
         JsonArray tunnels = jsonResponse.getJsonArray("tunnels");
         Optional<String> publicURLEntry = tunnels.stream().filter(o -> o instanceof JsonObject).map(o -> (JsonObject) o)
-                .filter(jo -> "http".equals(jo.getString("proto"))).map(jo -> jo.getString("public_url")).findFirst();
+                .filter(jo -> "https".equals(jo.getString("proto"))).map(jo -> jo.getString("public_url")).findFirst();
         if (publicURLEntry.isEmpty()) {
             throw new RuntimeException("Unable to determine public URL");
         }


### PR DESCRIPTION
@geoand I am an idiot and and forgot to delete my local cached ngrok 2.x EXE and now when it downloads 3.5.0 their API has changed slightly.

Its now `--config` instead of `-config` and they required `version: 2` in the YML.

https://ngrok.com/docs/agent/config/

