### PR TITLE
feat: generate config and use tunnel name to allow overrides

### DIFF
--- a/docs/modules/ROOT/pages/includes/quarkus-ngrok.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-ngrok.adoc
@@ -101,6 +101,8 @@ a| [[quarkus-ngrok_quarkus.ngrok.port]]`link:#quarkus-ngrok_quarkus.ngrok.port[q
 
 [.description]
 --
+The port where ngrok will be serving the local web interface and api
+
 ifdef::add-copy-button-to-env-var[]
 Environment variable: env_var_with_copy_button:+++QUARKUS_NGROK_PORT+++[]
 endif::add-copy-button-to-env-var[]
@@ -116,11 +118,30 @@ a| [[quarkus-ngrok_quarkus.ngrok.domain]]`link:#quarkus-ngrok_quarkus.ngrok.doma
 
 [.description]
 --
+The domain or hostname to use instead of the one ngrok generates. See https://ngrok.com/blog-post/free-static-domains-ngrok-users
+
 ifdef::add-copy-button-to-env-var[]
 Environment variable: env_var_with_copy_button:+++QUARKUS_NGROK_DOMAIN+++[]
 endif::add-copy-button-to-env-var[]
 ifndef::add-copy-button-to-env-var[]
 Environment variable: `+++QUARKUS_NGROK_DOMAIN+++`
+endif::add-copy-button-to-env-var[]
+--|string 
+|
+
+
+a| [[quarkus-ngrok_quarkus.ngrok.tunnel-name]]`link:#quarkus-ngrok_quarkus.ngrok.tunnel-name[quarkus.ngrok.tunnel-name]`
+
+
+[.description]
+--
+Name of the tunnel to start from ngrok default config instead of Quarkus configuration. Useful to use extended ngrok configuration.
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_NGROK_TUNNEL_NAME+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_NGROK_TUNNEL_NAME+++`
 endif::add-copy-button-to-env-var[]
 --|string 
 |

--- a/runtime/src/main/java/io/quarkiverse/ngrok/runtime/NgrokConfig.java
+++ b/runtime/src/main/java/io/quarkiverse/ngrok/runtime/NgrokConfig.java
@@ -49,13 +49,22 @@ public class NgrokConfig {
     /**
      * The port where ngrok will be serving the local web interface and api
      */
+    @ConfigItem
     public Optional<Integer> port;
 
     /**
      * The domain or hostname to use instead of the one ngrok generates.
      * See https://ngrok.com/blog-post/free-static-domains-ngrok-users
      */
+    @ConfigItem
     public Optional<String> domain;
+
+    /**
+     * Name of the tunnel to start from ngrok default config instead of Quarkus configuration. Useful to use extended ngrok
+     * configuration.
+     */
+    @ConfigItem
+    public Optional<String> tunnelName;
 
     public enum Region {
         United_States("us"),


### PR DESCRIPTION
this is implementing #103 but with a caveat.

Idea was that by generating config on every start and use  a tunnelname users could add the ngrok specfic config if they wanted to in the default ngrok yml config.

but turns out ngrok does not support as flexible merging of configs as I expected. each tunnel is fully replaced.
Also, not possible to have partial config - tunnles *must* specify addr to have tunneling.

meaning to have overrides take effect I must run it so the main config wins.

which this PR currently does.

It has the bad sideeffect thought that if users add any config to their ngrok.yml it will always win over whatever config quarkus has in its application.properties AND users must specify all the needed options in the main config if they want just one parameter overridden. Which feels against the principal of 'closest config should win'. 

So this PR does allow users to set any config they want in a tunnel using the quarkus app name...but it does it less nicely than I had expected.

maybe should instead fallback to the old behavior and only if you set `.tunnel-name` would we run with that specifc named tunnel which you as user would need to ensure it is present in the config ? 


wdyt?
