### PR TITLE
Fix #150: Allow deletion of certificate policy

### DIFF
--- a/deployment/pom.xml
+++ b/deployment/pom.xml
@@ -18,6 +18,10 @@
       <artifactId>quarkus-fs-util</artifactId>
     </dependency>
     <dependency>
+      <groupId>commons-io</groupId>
+      <artifactId>commons-io</artifactId>
+    </dependency>
+    <dependency>
       <groupId>io.quarkiverse.ngrok</groupId>
       <artifactId>quarkus-ngrok</artifactId>
       <version>${project.version}</version>

--- a/docs/modules/ROOT/pages/includes/quarkus-ngrok.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-ngrok.adoc
@@ -146,4 +146,38 @@ endif::add-copy-button-to-env-var[]
 --|string 
 |
 
+
+a| [[quarkus-ngrok_quarkus-ngrok-api-key]]`link:#quarkus-ngrok_quarkus-ngrok-api-key[quarkus.ngrok.api-key]`
+
+
+[.description]
+--
+API key for ngrok if you need to perform any API operations such as delete-certificate-management-policy.
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_NGROK_API_KEY+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_NGROK_API_KEY+++`
+endif::add-copy-button-to-env-var[]
+--|string 
+|
+
+
+a| [[quarkus-ngrok_quarkus-ngrok-delete-certificate-domain-id]]`link:#quarkus-ngrok_quarkus-ngrok-delete-certificate-domain-id[quarkus.ngrok.delete-certificate-domain-id]`
+
+
+[.description]
+--
+Reserved domain unique identifier for revoking certificate upon startup. Example: 'rd_2hrGw0rqFLOm9pcXf4dlbdNfrus' If this value is not null the certificate will be revoked upon dev service startup.
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_NGROK_DELETE_CERTIFICATE_DOMAIN_ID+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_NGROK_DELETE_CERTIFICATE_DOMAIN_ID+++`
+endif::add-copy-button-to-env-var[]
+--|string 
+|
+
 |===

--- a/runtime/src/main/java/io/quarkiverse/ngrok/runtime/NgrokConfig.java
+++ b/runtime/src/main/java/io/quarkiverse/ngrok/runtime/NgrokConfig.java
@@ -66,6 +66,19 @@ public class NgrokConfig {
     @ConfigItem
     public Optional<String> tunnelName;
 
+    /**
+     * API key for ngrok if you need to perform any API operations such as delete-certificate-management-policy.
+     */
+    @ConfigItem
+    public Optional<String> apiKey;
+
+    /**
+     * Reserved domain unique identifier for revoking certificate upon startup. Example: 'rd_2hrGw0rqFLOm9pcXf4dlbdNfrus'
+     * If this value is not null the certificate will be revoked upon dev service startup.
+     */
+    @ConfigItem
+    public Optional<String> deleteCertificateDomainId;
+
     public enum Region {
         United_States("us"),
         Europe("eu"),


### PR DESCRIPTION
Fix #150: Allow deletion of certificate policy

if you add these two new props..

```properties
%dev.quarkus.ngrok.api-key=key123
%dev.quarkus.ngrok.delete-certificate-domain-id=domain456
```

It will attempt to delete your certificate policy before starting the ngrok client.