### PR TITLE
Fix quarkus.ngrok-auth-token property in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ quarkus ext add io.quarkiverse.ngrok:quarkus-ngrok
 
 ## Usage
 
-1. Get a [ngrok auth token](https://ngrok.com/docs/getting-started/#step-2-connect-your-account) and configure it using ngrok or set it via `quarkus.ngrok.authtoken`
+1. Get a [ngrok auth token](https://ngrok.com/docs/getting-started/#step-2-connect-your-account) and configure it using ngrok or set it via `quarkus.ngrok.auth-token`
 
 2. A short while after the application has started, you should see something in the application logs like:
 


### PR DESCRIPTION
Hi,

there is a typo in README.md regarding `quarkus.ngrok.auth-token` property (in docs the property is correct). Hope it helps :) 